### PR TITLE
Use erlang:nif_error to play nice with dialyzer

### DIFF
--- a/src/statfs.erl
+++ b/src/statfs.erl
@@ -92,14 +92,14 @@ df_pretty() ->
 %%%
 -spec statfs(Path :: string()) -> {ok, statfs()} | {error, term()}.
 statfs(_Path) ->
-    {ok, #statfs{}}.
+    erlang:nif_error(nif_library_not_loaded).
 
 %%%
 %%% mounts NIF
 %%%
 -spec mounts() -> {ok, [mount()]} | {error, term()}.
 mounts() ->
-    {ok, []}.
+    erlang:nif_error(nif_library_not_loaded).
 
 %%%===================================================================
 %%% Internal functions


### PR DESCRIPTION
Without this, dialyzer deduces that `statfs/1` and `mounts/0` will always return the values from these default implementations which can then produce dialyzer errors for callers of these functions.